### PR TITLE
Fix allocation of a vector cell

### DIFF
--- a/vm/core/gc.c
+++ b/vm/core/gc.c
@@ -345,7 +345,7 @@ obj alloc_vec_cell (uint16 n, obj from)
 	// this includes a 4-byte vector space header
 	n = ((n+3) >> 2) + 1;
 
-	while ((VEC_TO_RAM_OBJ(MAX_RAM_ENCODING) - free_vec_pointer) < n) {
+	while ((VEC_TO_RAM_OBJ(MAX_VEC_ENCODING) - free_vec_pointer) < n) {
 		// free space too small, trigger gc
 		if (gc_done) { // we gc'd, but no space is big enough for the vector
 			ERROR("alloc_vec_cell", "no room for vector");


### PR DESCRIPTION
The end of vector space is at MAX_VEC_ENCODING, not MAX_RAM_ENCODING.
